### PR TITLE
feat: SEAC-0: Handle identity already exists error in CreateIdentity and CreateMult…

### DIFF
--- a/adapters/httpserver/admin_handler.go
+++ b/adapters/httpserver/admin_handler.go
@@ -102,6 +102,10 @@ func (s *Server) CreateIdentity(c echo.Context) error {
 
 	id, err := s.IdentityService.CreateIdentity(ctx, s.MapperService.ToIdentity(req))
 	if err != nil {
+		if errors.Is(err, identity.ErrIdentityAlreadyExists) {
+			return s.error(c, apperror.ErrIdentityAlreadyExists(err))
+		}
+
 		return s.error(c, apperror.ErrInternalServer(err))
 	}
 
@@ -158,6 +162,10 @@ func (s *Server) CreateMultipleIdentities(c echo.Context) error {
 
 	ids, err := s.IdentityService.CreateMultipleIdentities(ctx, simpleIdentities)
 	if err != nil {
+		if errors.Is(err, identity.ErrIdentityAlreadyExists) {
+			return s.error(c, apperror.ErrIdentityAlreadyExists(err))
+		}
+
 		return s.error(c, apperror.ErrInternalServer(err))
 	}
 

--- a/adapters/httpserver/admin_handler.go
+++ b/adapters/httpserver/admin_handler.go
@@ -84,6 +84,7 @@ func (s *Server) ListIdentities(c echo.Context) error {
 // @Success 200 {object} model.SuccessResponse{data=identity.Identity}
 // @Failure 400 {object} model.ErrorResponse
 // @Failure 401 {object} model.ErrorResponse
+// @Failure 409 {object} model.ErrorResponse
 // @Failure 500 {object} model.ErrorResponse
 // @Router /admin/identities [post]
 func (s *Server) CreateIdentity(c echo.Context) error {
@@ -137,6 +138,7 @@ func (s *Server) CreateIdentity(c echo.Context) error {
 // @Success 200 {object} model.SuccessResponse{data=[]identity.Identity}
 // @Failure 400 {object} model.ErrorResponse
 // @Failure 401 {object} model.ErrorResponse
+// @Failure 409 {object} model.ErrorResponse
 // @Failure 500 {object} model.ErrorResponse
 // @Router /admin/identities/bulk [post]
 func (s *Server) CreateMultipleIdentities(c echo.Context) error {

--- a/adapters/httpserver/file_handler.go
+++ b/adapters/httpserver/file_handler.go
@@ -114,6 +114,9 @@ func (s *Server) GetMetadata(c echo.Context) error {
 	}
 
 	isStarred, err := s.FileStore.IsStarred(ctx, f.ID, uuid.MustParse(id.ID))
+	if err != nil {
+		return s.error(c, apperror.ErrInternalServer(err))
+	}
 
 	return s.success(c, model.GetMetadataResponse{
 		File:    *f.Response().WithUserRoles(userRoles).WithIsStarred(isStarred),

--- a/adapters/services/identity.go
+++ b/adapters/services/identity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/SeaCloudHub/backend/pkg/pagination"
 
@@ -219,6 +220,10 @@ func (s *IdentityService) CreateIdentity(ctx context.Context, in identity.Simple
 	).Execute()
 	if err != nil {
 		if _, genericErr := assertKratosError[kratos.ErrorGeneric](err); genericErr != nil {
+			if genericErr.Error.GetCode() == http.StatusConflict {
+				return nil, identity.ErrIdentityAlreadyExists
+			}
+
 			return nil, fmt.Errorf("error creating identity: %s", genericErr.Error.GetReason())
 		}
 
@@ -254,6 +259,10 @@ func (s *IdentityService) CreateMultipleIdentities(ctx context.Context,
 			Identities: identitiesPatch}).Execute()
 	if err != nil {
 		if _, genericErr := assertKratosError[kratos.ErrorGeneric](err); genericErr != nil {
+			if genericErr.Error.GetCode() == http.StatusConflict {
+				return nil, identity.ErrIdentityAlreadyExists
+			}
+
 			return nil, fmt.Errorf("error creating identities: %s", genericErr.Error.Message)
 		}
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -212,6 +212,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/model.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/model.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -281,6 +287,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/model.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/model.ErrorResponse"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -209,6 +209,12 @@
                             "$ref": "#/definitions/model.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/model.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -278,6 +284,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/model.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/model.ErrorResponse"
                         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -797,6 +797,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/model.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/model.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
@@ -1157,6 +1161,10 @@ paths:
             $ref: '#/definitions/model.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/model.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/model.ErrorResponse'
         "500":

--- a/domain/identity/identity.go
+++ b/domain/identity/identity.go
@@ -10,13 +10,14 @@ import (
 )
 
 var (
-	ErrInvalidCredentials  = errors.New("invalid credentials")
-	ErrIncorrectPassword   = errors.New("incorrect password")
-	ErrInvalidPassword     = errors.New("invalid password")
-	ErrInvalidSession      = errors.New("invalid session")
-	ErrSessionTooOld       = errors.New("session too old")
-	ErrIdentityNotFound    = errors.New("identity not found")
-	ErrIdentityWasDisabled = errors.New("identity was disabled")
+	ErrInvalidCredentials    = errors.New("invalid credentials")
+	ErrIncorrectPassword     = errors.New("incorrect password")
+	ErrInvalidPassword       = errors.New("invalid password")
+	ErrInvalidSession        = errors.New("invalid session")
+	ErrSessionTooOld         = errors.New("session too old")
+	ErrIdentityNotFound      = errors.New("identity not found")
+	ErrIdentityWasDisabled   = errors.New("identity was disabled")
+	ErrIdentityAlreadyExists = errors.New("identity already exists")
 )
 
 type Service interface {

--- a/pkg/apperror/4xx.go
+++ b/pkg/apperror/4xx.go
@@ -22,6 +22,7 @@ const (
 	RefreshTokenRequiredCode    = "403008"
 	EntityNotFoundCode          = "404006"
 	IdentityNotFoundCode        = "404007"
+	IdentityAlreadyExistsCode   = "409001"
 )
 
 // 400 Bad Request
@@ -94,4 +95,9 @@ func ErrEntityNotFound(err error) Error {
 
 func ErrIdentityNotFound(err error) Error {
 	return NewError(err, http.StatusNotFound, IdentityNotFoundCode, "Identity not found")
+}
+
+// 409 Conflict
+func ErrIdentityAlreadyExists(err error) Error {
+	return NewError(err, http.StatusConflict, IdentityAlreadyExistsCode, "Identity already exists")
 }


### PR DESCRIPTION
…ipleIdentities

The code changes in this commit modify the `CreateIdentity` and `CreateMultipleIdentities` functions in the `admin_handler.go` file and the `CreateIdentity` function in the `identity.go` file.

The changes add error handling for the `identity.ErrIdentityAlreadyExists` error. If this error occurs, the appropriate error response is returned to the client.